### PR TITLE
Package version fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ cargo install --path .
 #### Commands:
 
 - `new`: Create a new project
+- `init`: Creates a new project in the existing directory
 - `run`: Run the current project
 - `help`: Print this message or the help of the given subcommand(s)
+
 
 #### Options:
 


### PR DESCRIPTION
Resolved dependency issue when adding new packages with versions

Previously dependencies were shown as :
```
//Packet.toml

"pandas==2.1.0" = ""
```
Fixed it into putting the dependencies as :

`pandas = "2.1.0"`

Also fixed the issue where when new dependencies were added, the previous ones would not be updated.

